### PR TITLE
perf: Alloc task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4861,6 +4861,7 @@ dependencies = [
  "const-gen",
  "critical-section",
  "display-interface",
+ "embassy-executor",
  "embassy-futures",
  "embassy-sync",
  "embassy-time",

--- a/lib/rktk/Cargo.toml
+++ b/lib/rktk/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true, features = ["derive"] }
 
 paste = { workspace = true }
 itertools = { version = "0.14.0", default-features = false }
-futures = { workspace = true }
+futures = { workspace = true, features = ["async-await"] }
 
 
 rktk-keymanager = { workspace = true, features = ["state"] }

--- a/lib/rktk/Cargo.toml
+++ b/lib/rktk/Cargo.toml
@@ -13,6 +13,7 @@ readme = "../../README.md"
 embassy-time = { workspace = true }
 embassy-sync = { workspace = true }
 embassy-futures = { workspace = true }
+embassy-executor = { workspace = true }
 embedded-io-async = { workspace = true }
 
 usbd-hid = { workspace = true }
@@ -54,4 +55,5 @@ schemars = "0.8.21"
 macro_rules_attribute = { workspace = true }
 
 [features]
-_check = []
+_check = ["alloc"]
+alloc = []

--- a/lib/rktk/src/drivers/interface/mod.rs
+++ b/lib/rktk/src/drivers/interface/mod.rs
@@ -23,7 +23,7 @@ pub trait DriverBuilder {
 pub trait DriverBuilderWithTask {
     type Driver;
     type Error: core::fmt::Debug;
-    async fn build(self) -> Result<(Self::Driver, impl BackgroundTask), Self::Error>;
+    async fn build(self) -> Result<(Self::Driver, impl BackgroundTask + 'static), Self::Error>;
 }
 
 pub trait BackgroundTask {

--- a/lib/rktk/src/lib.rs
+++ b/lib/rktk/src/lib.rs
@@ -27,6 +27,9 @@
 
 #![no_std]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub mod config;
 pub mod drivers;
 pub mod hooks;

--- a/lib/rktk/src/task/main_loop/mod.rs
+++ b/lib/rktk/src/task/main_loop/mod.rs
@@ -105,7 +105,7 @@ pub async fn start<
         None
     };
 
-    sjoin::join(
+    sjoin::join!(
         async {
             if let Some(split) = split {
                 if is_master {
@@ -165,7 +165,6 @@ pub async fn start<
                     }
                 }
             }
-        },
-    )
-    .await;
+        }
+    );
 }

--- a/lib/rktk/src/task/main_loop/mod.rs
+++ b/lib/rktk/src/task/main_loop/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         Hooks,
     },
     task::channels::split::{M2S_CHANNEL, S2M_CHANNEL},
+    utils::sjoin,
 };
 use embassy_futures::{
     join::join,
@@ -40,14 +41,14 @@ pub async fn start<
     EN: EncoderDriver,
     M: MouseDriver,
     SP: SplitDriver,
-    RGB: RgbDriver,
+    RGB: RgbDriver + 'static,
     Ble: BleDriver,
     Usb: UsbDriver,
     S: StorageDriver,
     CH: CommonHooks,
     MH: MasterHooks,
     SH: SlaveHooks,
-    BH: RgbHooks,
+    BH: RgbHooks + 'static,
 >(
     system: &Sys,
     ble: Option<Ble>,
@@ -104,19 +105,7 @@ pub async fn start<
         None
     };
 
-    join(
-        async {
-            if let Some(rgb) = rgb {
-                match hand {
-                    Hand::Right => {
-                        rgb::start::<{ KEYBOARD.right_rgb_count }>(rgb, hooks.rgb, rgb_m2s_tx).await
-                    }
-                    Hand::Left => {
-                        rgb::start::<{ KEYBOARD.left_rgb_count }>(rgb, hooks.rgb, rgb_m2s_tx).await
-                    }
-                }
-            }
-        },
+    sjoin::join(
         async {
             if let Some(split) = split {
                 if is_master {
@@ -163,6 +152,18 @@ pub async fn start<
                     hooks.master,
                 )
                 .await;
+            }
+        },
+        async move {
+            if let Some(rgb) = rgb {
+                match hand {
+                    Hand::Right => {
+                        rgb::start::<{ KEYBOARD.right_rgb_count }>(rgb, hooks.rgb, rgb_m2s_tx).await
+                    }
+                    Hand::Left => {
+                        rgb::start::<{ KEYBOARD.left_rgb_count }>(rgb, hooks.rgb, rgb_m2s_tx).await
+                    }
+                }
             }
         },
     )

--- a/lib/rktk/src/task/mod.rs
+++ b/lib/rktk/src/task/mod.rs
@@ -92,7 +92,7 @@ pub async fn start<
         .double_reset_usb_boot(Duration::from_millis(RKTK_CONFIG.double_tap_threshold))
         .await;
 
-    sjoin::join(
+    sjoin::join!(
         async move {
             let mouse = if let Some(mouse_builder) = drivers.mouse_builder {
                 match mouse_builder.build().await {
@@ -125,7 +125,7 @@ pub async fn start<
                 (None, None)
             };
 
-            sjoin::join3(
+            sjoin::join!(
                 async {
                     main_loop::start(
                         &drivers.system,
@@ -152,15 +152,13 @@ pub async fn start<
                     if let Some(ble_task) = ble_task {
                         ble_task.run().await
                     }
-                },
-            )
-            .await;
+                }
+            );
         },
         async move {
             if let Some(display_builder) = drivers.display_builder {
                 display::start(display_builder).await;
             }
-        },
-    )
-    .await;
+        }
+    );
 }

--- a/lib/rktk/src/task/mod.rs
+++ b/lib/rktk/src/task/mod.rs
@@ -4,8 +4,8 @@ use crate::{
     config::keymap::Keymap,
     drivers::{interface::system::SystemDriver, Drivers},
     hooks::interface::*,
+    utils::sjoin,
 };
-use embassy_futures::join::{join, join3};
 use embassy_time::Duration;
 
 use crate::{
@@ -38,19 +38,19 @@ pub async fn start<
     Ble: BleDriver,
     Usb: UsbDriver,
     Split: SplitDriver,
-    Rgb: RgbDriver,
+    Rgb: RgbDriver + 'static,
     System: SystemDriver,
     Storage: StorageDriver,
     Mouse: MouseDriver,
     Display: DisplayDriver,
     MouseBuilder: DriverBuilder<Output = Mouse>,
-    DisplayBuilder: DriverBuilder<Output = Display>,
+    DisplayBuilder: DriverBuilder<Output = Display> + 'static,
     UsbBuilder: DriverBuilderWithTask<Driver = Usb>,
     BleBuilder: DriverBuilderWithTask<Driver = Ble>,
     CH: CommonHooks,
     MH: MasterHooks,
     SH: SlaveHooks,
-    BH: RgbHooks,
+    BH: RgbHooks + 'static,
 >(
     drivers: Drivers<
         KeyScan,
@@ -92,13 +92,8 @@ pub async fn start<
         .double_reset_usb_boot(Duration::from_millis(RKTK_CONFIG.double_tap_threshold))
         .await;
 
-    join(
+    sjoin::join(
         async move {
-            if let Some(display_builder) = drivers.display_builder {
-                display::start(display_builder).await;
-            }
-        },
-        async {
             let mouse = if let Some(mouse_builder) = drivers.mouse_builder {
                 match mouse_builder.build().await {
                     Ok(mut mouse) => {
@@ -130,17 +125,7 @@ pub async fn start<
                 (None, None)
             };
 
-            join3(
-                async {
-                    if let Some(usb_task) = usb_task {
-                        usb_task.run().await
-                    }
-                },
-                async {
-                    if let Some(ble_task) = ble_task {
-                        ble_task.run().await
-                    }
-                },
+            sjoin::join3(
                 async {
                     main_loop::start(
                         &drivers.system,
@@ -158,8 +143,23 @@ pub async fn start<
                     )
                     .await;
                 },
+                async {
+                    if let Some(usb_task) = usb_task {
+                        usb_task.run().await
+                    }
+                },
+                async {
+                    if let Some(ble_task) = ble_task {
+                        ble_task.run().await
+                    }
+                },
             )
             .await;
+        },
+        async move {
+            if let Some(display_builder) = drivers.display_builder {
+                display::start(display_builder).await;
+            }
         },
     )
     .await;

--- a/lib/rktk/src/utils.rs
+++ b/lib/rktk/src/utils.rs
@@ -64,7 +64,7 @@ pub mod sjoin {
             };
 
             #[cfg(not(feature = "alloc"))]
-            futures::join::join!($f1, $($future:ident),* ).await;
+            futures::join!($f1, $($future),* );
         };
     }
     pub(crate) use join;

--- a/lib/rktk/src/utils.rs
+++ b/lib/rktk/src/utils.rs
@@ -28,6 +28,7 @@ macro_rules! display_state {
         let _ = DISPLAY_CONTROLLER.try_send(DisplayMessage::$mes_type($val));
     }};
 }
+
 pub(crate) use display_state;
 
 #[cfg(target_arch = "arm")]
@@ -40,3 +41,35 @@ pub type Channel<T, const N: usize> = embassy_sync::channel::Channel<RawMutex, T
 pub type Sender<'a, T, const N: usize> = embassy_sync::channel::Sender<'a, RawMutex, T, N>;
 pub type Receiver<'a, T, const N: usize> = embassy_sync::channel::Receiver<'a, RawMutex, T, N>;
 pub type Signal<T> = embassy_sync::signal::Signal<RawMutex, T>;
+
+/// sjoin or "spawn or join"
+pub mod sjoin {
+    use core::future::Future;
+
+    macro_rules! join_or_spawn {
+        ($name:ident, $f1:ident: $f1t:ident, $($fs:ident: $fst:ident),* ) => {
+            pub async fn $name<O, $f1t: Future<Output = O>, $($fst: Future + 'static),*>($f1: $f1t, $($fs: $fst),*) -> O {
+                #[cfg(feature = "alloc")]
+                {
+                    use alloc::boxed::Box;
+
+                    let ex = embassy_executor::Spawner::for_current_executor().await;
+                    $(
+                        let ts = Box::leak(Box::new(embassy_executor::raw::TaskStorage::new()));
+                        let st = ts.spawn(|| $fs);
+                        ex.spawn(st)
+                            .unwrap();
+                    )*
+                    $f1.await
+                }
+
+                #[cfg(not(feature = "alloc"))]
+                embassy_futures::join::$name($f1, $($fs),*).await.0
+            }
+        };
+    }
+
+    join_or_spawn!(join, f1: F1, f2: F2);
+    join_or_spawn!(join3, f1: F1, f2: F2, f3: F3);
+    join_or_spawn!(join4, f1: F1, f2: F2, f3: F3, f4: F4);
+}


### PR DESCRIPTION
closes #34

# Overview
This PR adds ability to spawn task using alloc crate and `Box::leak`:
```rust
let storage = Box::leak(Box::new(embassy_executor::raw::TaskStorage::new()));
storage.spawn(future);
```

# Description
This PR adds `join` macro and `alloc` feature for `rktk`. If `alloc` is not enabled, this macro just falls back to `futures::join::join!` macro, but if enabled, it creates `Box` that contains task and spawns it. 
First future is executed normally (not spawned) and other futures are spawned. 

## Alternative implementation
Firstly, I tried to create function instead of macro, like below:
```rust
    macro_rules! join_or_spawn {
        ($name:ident, $f1:ident: $f1t:ident, $($fs:ident: $fst:ident),* ) => {
            #[cfg(feature = "alloc")]
            #[inline(always)]
            pub async fn $name<O, $f1t: Future<Output = O>, $($fst: Future + 'static),*>($f1: $f1t, $($fs: $fst),*) -> O {
                use alloc::boxed::Box;
                {
                    let ex = embassy_executor::Spawner::for_current_executor().await;
                    $(
                        let ts = Box::leak(Box::new(embassy_executor::raw::TaskStorage::new()));
                        let st = ts.spawn(|| $fs);
                        ex.spawn(st).unwrap();
                    )*
                }

                $f1.await
            }

            #[cfg(not(feature = "alloc"))]
            pub use embassy_futures::join::*;
        };
    }
```

But this increases stack usage significantly, so I switched to macro way.

# Performance
I have not actually measured it, but the current rktk has about 20 future joins, which would have been a reasonable overhead to poll.
ref: https://embassy.dev/book/#_multiple_tasks_or_one_task_with_multiple_futures