### PR TITLE
feat: Advanced RGB using blinksy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5618,7 +5618,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
- "smart-leds",
  "ssmarshal",
  "static_cell",
  "strum",
@@ -5739,7 +5738,6 @@ dependencies = [
  "rktk",
  "rktk-drivers-common",
  "rktk-log",
- "smart-leds",
  "ssd1306",
  "static_cell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 [[package]]
 name = "blinksy"
 version = "0.4.0"
-source = "git+https://github.com/ahdinosaur/blinksy?branch=noise-functions#14d369c0727bcb8fb5214062f47b047322aa5b26"
+source = "git+https://github.com/ahdinosaur/blinksy#e58fcced312259ccb96fde9219a97a838b3f9796"
 dependencies = [
  "defmt 0.3.100",
  "embedded-hal 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "blinksy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a54a984d31cc769ebd5c78a1af3f487ad908ef628795cf919c60e01afc1197"
+dependencies = [
+ "defmt 0.3.100",
+ "embedded-hal 1.0.0",
+ "fugit",
+ "glam",
+ "heapless 0.8.0",
+ "noise-fork-nostd",
+ "num-traits",
+ "smart-leds-trait",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fugit"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
+dependencies = [
+ "gcd",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2844,12 @@ checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "gdk"
@@ -3042,6 +3073,15 @@ dependencies = [
  "libc",
  "system-deps",
  "winapi",
+]
+
+[[package]]
+name = "glam"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a99dbe56b72736564cfa4b85bf9a33079f16ae8b74983ab06af3b1a3696b11"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -3886,6 +3926,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,6 +4328,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "noise-fork-nostd"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0eb27381fa459e4ea14a5d69240e32b48732de5aaeaf0e4a6f6c95199a8d5a3"
+dependencies = [
+ "num-traits",
+ "rand 0.9.1",
+ "rand_xorshift",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,6 +4467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5304,6 +5362,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5342,6 +5409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5357,6 +5430,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5510,6 +5592,7 @@ dependencies = [
 name = "rktk"
 version = "0.2.0"
 dependencies = [
+ "blinksy",
  "const-gen",
  "critical-section",
  "defmt 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5713,7 +5713,6 @@ dependencies = [
  "rktk-log",
  "sequential-storage",
  "serde",
- "smart-leds",
  "ssmarshal",
  "static_cell",
  "usbd-hid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,15 +528,14 @@ dependencies = [
 [[package]]
 name = "blinksy"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a54a984d31cc769ebd5c78a1af3f487ad908ef628795cf919c60e01afc1197"
+source = "git+https://github.com/ahdinosaur/blinksy?branch=noise-functions#14d369c0727bcb8fb5214062f47b047322aa5b26"
 dependencies = [
  "defmt 0.3.100",
  "embedded-hal 1.0.0",
  "fugit",
  "glam",
  "heapless 0.8.0",
- "noise-fork-nostd",
+ "noise-functions",
  "num-traits",
  "smart-leds-trait",
 ]
@@ -4328,14 +4327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
-name = "noise-fork-nostd"
-version = "0.9.0"
+name = "noise-functions"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0eb27381fa459e4ea14a5d69240e32b48732de5aaeaf0e4a6f6c95199a8d5a3"
+checksum = "3420c74fd988a5c7da54fad9b8dba218f15431833817913d252dc59002c199c5"
 dependencies = [
- "num-traits",
- "rand 0.9.1",
- "rand_xorshift",
+ "libm",
 ]
 
 [[package]]
@@ -5362,15 +5359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_core 0.9.3",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5409,12 +5397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-
-[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5430,15 +5412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ cortex-m-rt = "0.7.0"
 critical-section = "1.2.0"
 portable-atomic = "1.11.0"
 usbd-hid = "0.8.2"
-smart-leds = "0.4.0"
 display-interface = "0.5.0"
 embedded-graphics = "0.8.1"
 ssd1306 = { version = "0.10.0", features = ["async"] }

--- a/examples/corne-nrf/rktk.json
+++ b/examples/corne-nrf/rktk.json
@@ -3,9 +3,7 @@
   "constant": {
     "keyboard": {
       "cols": 12,
-      "rows": 4,
-      "right_rgb_count": 27,
-      "left_rgb_count": 27
+      "rows": 4
     }
   },
 

--- a/examples/corne-rp/rktk.json
+++ b/examples/corne-rp/rktk.json
@@ -3,9 +3,7 @@
   "constant": {
     "keyboard": {
       "cols": 12,
-      "rows": 4,
-      "right_rgb_count": 27,
-      "left_rgb_count": 27
+      "rows": 4
     }
   },
 

--- a/lib/rktk-drivers-nrf/Cargo.toml
+++ b/lib/rktk-drivers-nrf/Cargo.toml
@@ -64,7 +64,6 @@ static_cell = { workspace = true }
 heapless = { workspace = true }
 bitvec = { version = "1.0.1", default-features = false }
 ssmarshal = { workspace = true }
-smart-leds = { workspace = true }
 usbd-hid = { workspace = true }
 atomic-pool = "2.0.0"
 

--- a/lib/rktk-drivers-rp/Cargo.toml
+++ b/lib/rktk-drivers-rp/Cargo.toml
@@ -34,8 +34,6 @@ embassy-rp = { workspace = true, features = [
 ssd1306 = { workspace = true }
 display-interface = { workspace = true }
 
-smart-leds = { workspace = true }
-
 pio = "0.3.0"
 
 fixed = { workspace = true }

--- a/lib/rktk-drivers-rp/src/rgb/ws2812_pio.rs
+++ b/lib/rktk-drivers-rp/src/rgb/ws2812_pio.rs
@@ -8,7 +8,7 @@ use embassy_rp::{Peripheral, PeripheralRef, clocks, into_ref};
 use embassy_time::Timer;
 use fixed::types::U24F8;
 use fixed_macro::fixed;
-use rktk::drivers::interface::rgb::RgbDriver;
+use rktk::drivers::interface::rgb::{LedRgb, RgbDriver};
 
 pub struct Ws2812Pio<'a, const MAX_LED_COUNT: usize, I: Instance> {
     dma: PeripheralRef<'a, AnyChannel>,
@@ -90,15 +90,13 @@ impl<const MAX_LED_COUNT: usize, I: Instance + 'static> RgbDriver
 {
     type Error = Infallible;
 
-    async fn write<IT: IntoIterator<Item = rktk::drivers::interface::rgb::Rgb8>>(
+    async fn write<IT: IntoIterator<Item = LedRgb<u8>>>(
         &mut self,
         pixels: IT,
-        brightness: f32,
-        correction: rktk::drivers::interface::rgb::ColorCorrection,
     ) -> Result<(), Self::Error> {
         let mut words = [0u32; MAX_LED_COUNT];
         for (p, w) in pixels.into_iter().zip(words.iter_mut()) {
-            *w = (u32::from(p.green) << 24) | (u32::from(p.red) << 16) | (u32::from(p.blue) << 8);
+            *w = (u32::from(p[1]) << 24) | (u32::from(p[0]) << 16) | (u32::from(p[2]) << 8);
         }
 
         // DMA transfer

--- a/lib/rktk/Cargo.toml
+++ b/lib/rktk/Cargo.toml
@@ -42,6 +42,7 @@ document-features = { workspace = true }
 strum = { workspace = true }
 itertools = { version = "0.14.0", default-features = false }
 paste = { workspace = true }
+blinksy = "0.4.0"
 
 [build-dependencies]
 ssmarshal = { workspace = true, default-features = true }

--- a/lib/rktk/Cargo.toml
+++ b/lib/rktk/Cargo.toml
@@ -28,7 +28,6 @@ usbd-hid = { workspace = true }
 
 embedded-graphics = { workspace = true }
 display-interface = { workspace = true }
-smart-leds = { workspace = true }
 
 heapless = { workspace = true }
 static_cell = { workspace = true }

--- a/lib/rktk/Cargo.toml
+++ b/lib/rktk/Cargo.toml
@@ -41,7 +41,7 @@ document-features = { workspace = true }
 strum = { workspace = true }
 itertools = { version = "0.14.0", default-features = false }
 paste = { workspace = true }
-blinksy = "0.4.0"
+blinksy = { git = "https://github.com/ahdinosaur/blinksy", branch = "noise-functions" }
 
 [build-dependencies]
 ssmarshal = { workspace = true, default-features = true }

--- a/lib/rktk/Cargo.toml
+++ b/lib/rktk/Cargo.toml
@@ -41,7 +41,7 @@ document-features = { workspace = true }
 strum = { workspace = true }
 itertools = { version = "0.14.0", default-features = false }
 paste = { workspace = true }
-blinksy = { git = "https://github.com/ahdinosaur/blinksy", branch = "noise-functions" }
+blinksy = { git = "https://github.com/ahdinosaur/blinksy" }
 
 [build-dependencies]
 ssmarshal = { workspace = true, default-features = true }

--- a/lib/rktk/build/main.rs
+++ b/lib/rktk/build/main.rs
@@ -72,6 +72,7 @@ pub fn generate(value: &str) -> Result<String, Box<dyn std::error::Error>> {
         schema::constant::KeymanagerConstantConfig,
         schema::dynamic::DynamicConfig,
         schema::dynamic::rktk::RktkConfig,
+        schema::dynamic::rktk::RktkRgbConfig,
         schema::dynamic::keyboard::KeyboardConfig,
         schema::dynamic::key_manager::KeyManagerConfig
     );

--- a/lib/rktk/build/schema/constant.rs
+++ b/lib/rktk/build/schema/constant.rs
@@ -21,14 +21,6 @@ pub struct KeyboardConstantConfig {
     /// The number of encoder keys.
     #[serde(default)]
     pub encoder_count: u8,
-
-    /// RGB led count for right side
-    #[serde(default)]
-    pub right_rgb_count: usize,
-
-    /// RGB led count for left side. This is also used for non-split keyboard.
-    #[serde(default)]
-    pub left_rgb_count: usize,
 }
 
 #[macro_rules_attribute::apply(crate::schema::common_derive)]

--- a/lib/rktk/build/schema/constant.rs
+++ b/lib/rktk/build/schema/constant.rs
@@ -39,6 +39,10 @@ pub struct BufferSizeConfig {
     #[default(64)]
     pub split_channel: usize,
 
+    /// Size of the rgb command channel buffer
+    #[default(3)]
+    pub rgb_channel: usize,
+
     /// Size of the mouse event buffer
     #[default(4)]
     pub mouse_event: usize,

--- a/lib/rktk/build/schema/dynamic/rktk.rs
+++ b/lib/rktk/build/schema/dynamic/rktk.rs
@@ -3,6 +3,8 @@
 #[derive(smart_default::SmartDefault)]
 #[serde(default)]
 pub struct RktkConfig {
+    pub rgb: RktkRgbConfig,
+
     /// Threshold for double tap (ms).
     #[default(500)]
     pub double_tap_threshold: u64,
@@ -42,4 +44,24 @@ pub struct RktkConfig {
     /// This setting specifies that interval. (ms)
     #[default(10)]
     pub state_update_interval: u64,
+}
+
+/// RKTK RGB config
+#[macro_rules_attribute::apply(crate::schema::common_derive)]
+#[derive(smart_default::SmartDefault)]
+#[serde(default)]
+pub struct RktkRgbConfig {
+    /// Time(ms) to wait for the next RGB pattern update
+    ///
+    /// Lower values will result in smoother animations, but may increase power consumption.
+    /// Also, for heavy patterns, it may cause the MCU to be busy for a long time, which affects
+    /// mouse latency (especially).
+    #[default(16)]
+    pub pattern_update_interval: u64,
+
+    /// Initial RGB blightness
+    ///
+    /// Range: 0.0 to 1.0
+    #[default(0.5)]
+    pub default_brightness: f32,
 }

--- a/lib/rktk/schema.json
+++ b/lib/rktk/schema.json
@@ -46,6 +46,13 @@
           "format": "uint",
           "minimum": 0.0
         },
+        "rgb_channel": {
+          "description": "Size of the rgb command channel buffer",
+          "default": 3,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
         "rrp": {
           "description": "Size of the buffer used by rrp",
           "default": 512,

--- a/lib/rktk/schema.json
+++ b/lib/rktk/schema.json
@@ -347,6 +347,9 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "rgb": {
+          "$ref": "#/definitions/RktkRgbConfig"
+        },
         "scan_interval_keyboard": {
           "description": "Time (ms) to wait for the next keyboard scan",
           "default": 5,
@@ -379,6 +382,26 @@
           "description": "Swap the x and y values obtained from the mouse driver. This also affects the scroll direction.",
           "default": false,
           "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "RktkRgbConfig": {
+      "description": "RKTK RGB config",
+      "type": "object",
+      "properties": {
+        "default_brightness": {
+          "description": "Initial RGB blightness\n\nRange: 0.0 to 1.0",
+          "default": 0.5,
+          "type": "number",
+          "format": "float"
+        },
+        "pattern_update_interval": {
+          "description": "Time(ms) to wait for the next RGB pattern update\n\nLower values will result in smoother animations, but may increase power consumption. Also, for heavy patterns, it may cause the MCU to be busy for a long time, which affects mouse latency (especially).",
+          "default": 16,
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/lib/rktk/schema.json
+++ b/lib/rktk/schema.json
@@ -195,20 +195,6 @@
           "format": "uint8",
           "minimum": 0.0
         },
-        "left_rgb_count": {
-          "description": "RGB led count for left side. This is also used for non-split keyboard.",
-          "default": 0,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "right_rgb_count": {
-          "description": "RGB led count for right side",
-          "default": 0,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
         "rows": {
           "description": "The number of rows in the keyboard matrix.",
           "type": "integer",

--- a/lib/rktk/src/config/keymap.rs
+++ b/lib/rktk/src/config/keymap.rs
@@ -13,15 +13,29 @@ pub mod keymanager {
 pub mod rktk_keys {
     use rktk_keymanager::keycode::prelude::*;
 
-    /// Custom key id of rktk-keymanager which is specific to rktk.
-    /// It must be used with `Custom1` variant of [`rktk_keymanager::keycode::KeyCode`]
-    ///
-    /// Custom2 and Custom3 can be used by user.
-    #[derive(
-        Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter, strum::IntoStaticStr, strum::FromRepr,
-    )]
-    #[repr(u8)]
-    pub enum RktkKeys {
+    macro_rules! gen_rktk_keys {
+        ($($name:ident = $value:literal),* $(,)?) => {
+            /// Custom key id of rktk-keymanager which is specific to rktk.
+            /// It must be used with `Custom1` variant of [`rktk_keymanager::keycode::KeyCode`]
+            ///
+            /// Custom2 and Custom3 can be used by user.
+            #[derive(
+                Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter, strum::IntoStaticStr, strum::FromRepr,
+            )]
+            #[repr(u8)]
+            pub enum RktkKeys {
+                $(
+                    $name = $value,
+                )*
+            }
+
+            paste::paste! {
+                $(pub const [<$name:snake:upper>] : KeyAction = KeyAction::Normal(KeyCode::Custom1($value));)*
+            }
+        };
+    }
+
+    gen_rktk_keys! {
         FlashClear = 0,
         OutputBle = 1,
         OutputUsb = 2,
@@ -41,17 +55,6 @@ pub mod rktk_keys {
             write!(f, "{s}")
         }
     }
-    pub const FLASH_CLEAR: KeyAction =
-        KeyAction::Normal(KeyCode::Custom1(RktkKeys::FlashClear as u8));
-    pub const OUTPUT_BLE: KeyAction =
-        KeyAction::Normal(KeyCode::Custom1(RktkKeys::OutputBle as u8));
-    pub const OUTPUT_USB: KeyAction =
-        KeyAction::Normal(KeyCode::Custom1(RktkKeys::OutputUsb as u8));
-    pub const BLE_BOND_CLEAR: KeyAction =
-        KeyAction::Normal(KeyCode::Custom1(RktkKeys::BleBondClear as u8));
-    pub const BOOTLOADER: KeyAction =
-        KeyAction::Normal(KeyCode::Custom1(RktkKeys::Bootloader as u8));
-    pub const POWER_OFF: KeyAction = KeyAction::Normal(KeyCode::Custom1(RktkKeys::PowerOff as u8));
 }
 
 pub mod prelude {

--- a/lib/rktk/src/config/keymap.rs
+++ b/lib/rktk/src/config/keymap.rs
@@ -17,7 +17,10 @@ pub mod rktk_keys {
     /// It must be used with `Custom1` variant of [`rktk_keymanager::keycode::KeyCode`]
     ///
     /// Custom2 and Custom3 can be used by user.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter, strum::IntoStaticStr)]
+    #[derive(
+        Debug, Clone, Copy, PartialEq, Eq, strum::EnumIter, strum::IntoStaticStr, strum::FromRepr,
+    )]
+    #[repr(u8)]
     pub enum RktkKeys {
         FlashClear = 0,
         OutputBle = 1,
@@ -25,6 +28,10 @@ pub mod rktk_keys {
         BleBondClear = 3,
         Bootloader = 4,
         PowerOff = 5,
+        RgbOff = 6,
+        RgbBrightnessUp = 7,
+        RgbBrightnessDown = 8,
+        RgbPatternRainbow = 9,
     }
 
     use core::fmt::{self, Display, Formatter};
@@ -34,23 +41,6 @@ pub mod rktk_keys {
             write!(f, "{s}")
         }
     }
-
-    impl TryFrom<u8> for RktkKeys {
-        type Error = ();
-
-        fn try_from(value: u8) -> Result<Self, Self::Error> {
-            match value {
-                0 => Ok(Self::FlashClear),
-                1 => Ok(Self::OutputBle),
-                2 => Ok(Self::OutputUsb),
-                3 => Ok(Self::BleBondClear),
-                4 => Ok(Self::Bootloader),
-                5 => Ok(Self::PowerOff),
-                _ => Err(()),
-            }
-        }
-    }
-
     pub const FLASH_CLEAR: KeyAction =
         KeyAction::Normal(KeyCode::Custom1(RktkKeys::FlashClear as u8));
     pub const OUTPUT_BLE: KeyAction =

--- a/lib/rktk/src/config/mod.rs
+++ b/lib/rktk/src/config/mod.rs
@@ -36,8 +36,6 @@
 //!     "keyboard": {
 //!       "cols": 12,
 //!       "rows": 4,
-//!       "right_rgb_count": 27,
-//!       "left_rgb_count": 27
 //!     }
 //!   },
 //!   "dynamic": {

--- a/lib/rktk/src/config/mod.rs
+++ b/lib/rktk/src/config/mod.rs
@@ -78,19 +78,21 @@ use crate::task::display::default_display::DefaultDisplayConfig;
 include!(concat!(env!("OUT_DIR"), "/config.rs"));
 
 pub mod keymap;
+pub mod rgb;
 pub mod storage;
 
 /// rktk launch options.
 ///
 /// Some properties of this struct requires `'static` lifetime. Even if the value you want to use
 /// is not statically defined, you can obtain static lifetime using [`static_cell`] crate.
-pub struct RktkOpts<D: crate::task::display::DisplayConfig> {
+pub struct RktkOpts<D: crate::task::display::DisplayConfig, R: blinksy::layout::Layout2d> {
     /// Keymap of keyboard
     pub keymap: &'static keymap::Keymap,
     /// "dynamic" config
     pub config: &'static schema::DynamicConfig,
     /// Display layout
     pub display: D,
+    pub rgb_layout: R,
     /// Hand of the keyboard. This is used for split keyboard. For non-split keyboard, set this
     /// value to `None`.
     ///
@@ -103,11 +105,12 @@ pub struct RktkOpts<D: crate::task::display::DisplayConfig> {
 pub fn new_rktk_opts(
     keymap: &'static keymap::Keymap,
     hand: Option<Hand>,
-) -> RktkOpts<DefaultDisplayConfig> {
+) -> RktkOpts<DefaultDisplayConfig, rgb::DummyLayout> {
     RktkOpts {
         keymap,
         config: &DYNAMIC_CONFIG_FROM_FILE,
         display: DefaultDisplayConfig,
+        rgb_layout: rgb::DummyLayout,
         hand,
     }
 }

--- a/lib/rktk/src/config/rgb.rs
+++ b/lib/rktk/src/config/rgb.rs
@@ -1,0 +1,12 @@
+pub use blinksy::layout;
+pub use blinksy::layout2d;
+
+pub struct DummyLayout;
+
+impl layout::Layout2d for DummyLayout {
+    const PIXEL_COUNT: usize = 0;
+
+    fn shapes() -> impl Iterator<Item = layout::Shape2d> {
+        [].into_iter()
+    }
+}

--- a/lib/rktk/src/drivers/dummy.rs
+++ b/lib/rktk/src/drivers/dummy.rs
@@ -27,9 +27,12 @@ pub fn rgb() -> Option<impl RgbDriver> {
     pub enum Rgb {}
     impl RgbDriver for Rgb {
         type Error = Infallible;
-        async fn write<const N: usize>(
+
+        async fn write<I: IntoIterator<Item = blinksy::color::LinearSrgb>>(
             &mut self,
-            _colors: &[smart_leds::RGB8; N],
+            _pixels: I,
+            _brightness: f32,
+            _correction: blinksy::color::ColorCorrection,
         ) -> Result<(), Self::Error> {
             unreachable!()
         }

--- a/lib/rktk/src/drivers/dummy.rs
+++ b/lib/rktk/src/drivers/dummy.rs
@@ -15,24 +15,21 @@ use crate::drivers::interface::{
     encoder::EncoderDriver,
     mouse::MouseDriver,
     reporter::ReporterDriver,
-    rgb::{Rgb8, RgbDriver},
+    rgb::RgbDriver,
     split::SplitDriver,
     storage::StorageDriver,
     usb::{UsbReporterDriver, UsbReporterDriverBuilder},
     wireless::{WirelessReporterDriver, WirelessReporterDriverBuilder},
 };
 
-// Rgb
 pub fn rgb() -> Option<impl RgbDriver> {
     pub enum Rgb {}
     impl RgbDriver for Rgb {
         type Error = Infallible;
 
-        async fn write<I: IntoIterator<Item = Rgb8>>(
+        async fn write<I: IntoIterator<Item = blinksy::color::LedRgb<u8>>>(
             &mut self,
             _pixels: I,
-            _brightness: f32,
-            _correction: blinksy::color::ColorCorrection,
         ) -> Result<(), Self::Error> {
             unreachable!()
         }

--- a/lib/rktk/src/drivers/dummy.rs
+++ b/lib/rktk/src/drivers/dummy.rs
@@ -15,7 +15,7 @@ use crate::drivers::interface::{
     encoder::EncoderDriver,
     mouse::MouseDriver,
     reporter::ReporterDriver,
-    rgb::RgbDriver,
+    rgb::{Rgb8, RgbDriver},
     split::SplitDriver,
     storage::StorageDriver,
     usb::{UsbReporterDriver, UsbReporterDriverBuilder},
@@ -28,7 +28,7 @@ pub fn rgb() -> Option<impl RgbDriver> {
     impl RgbDriver for Rgb {
         type Error = Infallible;
 
-        async fn write<I: IntoIterator<Item = blinksy::color::LinearSrgb>>(
+        async fn write<I: IntoIterator<Item = Rgb8>>(
             &mut self,
             _pixels: I,
             _brightness: f32,

--- a/lib/rktk/src/drivers/interface/rgb.rs
+++ b/lib/rktk/src/drivers/interface/rgb.rs
@@ -2,23 +2,54 @@
 
 // TODO: Split backlight and underglow
 
-pub use blinksy::color::{ColorCorrection, LinearSrgb};
+pub use blinksy::color::ColorCorrection;
+use blinksy::color::LinearSrgb;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Rgb8 {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+}
+impl Rgb8 {
+    pub fn new(red: u8, green: u8, blue: u8) -> Self {
+        Self { red, green, blue }
+    }
+}
+
+impl From<LinearSrgb> for Rgb8 {
+    fn from(color: LinearSrgb) -> Self {
+        Self {
+            red: (color.red * 255.0) as u8,
+            green: (color.green * 255.0) as u8,
+            blue: (color.blue * 255.0) as u8,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RgbCommand {
     Start(RgbMode),
     Reset,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RgbMode {
-    Rainbow,
-    Blink,
-    // Color (rgb)
+    Off,
+    /// Color (rgb)
     SolidColor(u8, u8, u8),
+    Pattern(RgbPattern),
+    Custom,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RgbPattern {
+    Rainbow(f32, f32),
 }
 
 /// Driver for controlling the RGB leds.
@@ -31,7 +62,7 @@ pub trait RgbDriver: 'static {
     type Error: super::Error;
 
     // Required method
-    async fn write<I: IntoIterator<Item = LinearSrgb>>(
+    async fn write<I: IntoIterator<Item = Rgb8>>(
         &mut self,
         pixels: I,
         brightness: f32,

--- a/lib/rktk/src/drivers/interface/rgb.rs
+++ b/lib/rktk/src/drivers/interface/rgb.rs
@@ -18,6 +18,7 @@ pub enum RgbCommand {
     ///
     /// Range: 0.0 to 1.0
     Brightness(f32),
+    BrightnessDelta(f32),
     /// Reset RGB state and restart current RgbMode
     Reset,
 }

--- a/lib/rktk/src/drivers/interface/rgb.rs
+++ b/lib/rktk/src/drivers/interface/rgb.rs
@@ -45,6 +45,7 @@ pub enum RgbMode {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum RgbPattern {
     Rainbow(f32, f32),
+    NoisePerlin,
 }
 
 /// Driver for controlling the RGB leds.

--- a/lib/rktk/src/drivers/interface/rgb.rs
+++ b/lib/rktk/src/drivers/interface/rgb.rs
@@ -2,8 +2,8 @@
 
 // TODO: Split backlight and underglow
 
+pub use blinksy::color::{ColorCorrection, LinearSrgb};
 use serde::{Deserialize, Serialize};
-use smart_leds::RGB8;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -22,9 +22,19 @@ pub enum RgbMode {
 }
 
 /// Driver for controlling the RGB leds.
+///
+/// Basically, this is just async version trait of [`blinksy::driver::Driver`]. But color is
+/// limited to LinearSrgb to avoid complexity.
+/// TODO: When blinksy implements async drivers, remove this trait and use the blinksy one
+/// directly.
 pub trait RgbDriver: 'static {
     type Error: super::Error;
 
-    /// Write provided colors to leds.
-    async fn write<const N: usize>(&mut self, colors: &[RGB8; N]) -> Result<(), Self::Error>;
+    // Required method
+    async fn write<I: IntoIterator<Item = LinearSrgb>>(
+        &mut self,
+        pixels: I,
+        brightness: f32,
+        correction: ColorCorrection,
+    ) -> Result<(), Self::Error>;
 }

--- a/lib/rktk/src/hooks/interface/mod.rs
+++ b/lib/rktk/src/hooks/interface/mod.rs
@@ -3,8 +3,8 @@
 #![allow(async_fn_in_trait)]
 
 pub mod dongle;
-pub mod master;
-pub mod rgb;
+mod master;
+mod rgb;
 
 pub use common::CommonHooks;
 pub use master::MasterHooks;
@@ -13,8 +13,8 @@ pub use slave::SlaveHooks;
 
 mod common {
     use crate::{
-        drivers::interface::{keyscan::KeyscanDriver, mouse::MouseDriver, storage::StorageDriver},
         config::Hand,
+        drivers::interface::{keyscan::KeyscanDriver, mouse::MouseDriver, storage::StorageDriver},
     };
 
     /// Hooks common for both master and slave side

--- a/lib/rktk/src/hooks/interface/mod.rs
+++ b/lib/rktk/src/hooks/interface/mod.rs
@@ -3,15 +3,15 @@
 #![allow(async_fn_in_trait)]
 
 pub mod dongle;
-mod master;
-mod rgb;
+pub mod master;
+pub mod rgb;
 
 pub use common::CommonHooks;
 pub use master::MasterHooks;
 pub use rgb::RgbHooks;
 pub use slave::SlaveHooks;
 
-mod common {
+pub mod common {
     use crate::{
         config::Hand,
         drivers::interface::{keyscan::KeyscanDriver, mouse::MouseDriver, storage::StorageDriver},
@@ -30,7 +30,7 @@ mod common {
     }
 }
 
-mod slave {
+pub mod slave {
     use crate::drivers::interface::{keyscan::KeyscanDriver, mouse::MouseDriver};
 
     pub trait SlaveHooks {

--- a/lib/rktk/src/hooks/interface/rgb.rs
+++ b/lib/rktk/src/hooks/interface/rgb.rs
@@ -1,14 +1,6 @@
-use crate::drivers::interface::rgb::{RgbCommand, RgbDriver};
-
-pub use smart_leds::RGB8;
+use crate::drivers::interface::rgb::{RgbDriver, RgbMode};
 
 pub trait RgbHooks: 'static {
     async fn on_rgb_init(&mut self, _driver: &mut impl RgbDriver) {}
-    async fn on_rgb_process<const N: usize>(
-        &mut self,
-        _driver: &mut impl RgbDriver,
-        _command: &RgbCommand,
-        _rgb_data: &mut Option<[RGB8; N]>,
-    ) {
-    }
+    async fn on_rgb_process(&mut self, _driver: &mut impl RgbDriver, _rgb_mode: &mut RgbMode) {}
 }

--- a/lib/rktk/src/hooks/interface/rgb.rs
+++ b/lib/rktk/src/hooks/interface/rgb.rs
@@ -1,6 +1,24 @@
-use crate::drivers::interface::rgb::{RgbDriver, RgbMode};
+use crate::drivers::interface::rgb::*;
 
+/// Hooks related to RGB functionality.
+///
+/// This trait allows for custom RGB behavior to be implemented.
+/// These hooks are called in both master and slave sides of the keyboard.
 pub trait RgbHooks: 'static {
-    async fn on_rgb_init(&mut self, _driver: &mut impl RgbDriver) {}
+    /// Invoked after the RGB driver is initialized.
+    ///
+    /// * `_driver`: [`RgbDriver`] instance to control RGB.
+    /// * `_is_master`: If true, this is the master side of the keyboard.
+    async fn on_rgb_init(&mut self, _driver: &mut impl RgbDriver, _is_master: bool) {}
+
+    /// Invoked
+    /// - after the [`RgbCommand`] is send and RGB task received it
+    /// - before the RGB task processes the command.
+    ///
+    /// You can use this hook to modify the RGB mode before the RGB task processes.
+    ///
+    /// * `_driver`: [`RgbDriver`] instance to control RGB.
+    /// * `_rgb_mode`: [`RgbMode`] to be processed.
     async fn on_rgb_process(&mut self, _driver: &mut impl RgbDriver, _rgb_mode: &mut RgbMode) {}
+    async fn custom_rgb(&mut self, _driver: &mut impl RgbDriver, _brightness: f32) {}
 }

--- a/lib/rktk/src/task/channels.rs
+++ b/lib/rktk/src/task/channels.rs
@@ -4,11 +4,12 @@ use crate::utils::{Channel, Receiver, Sender};
 use embassy_sync::channel::DynamicSender;
 
 pub mod rgb {
-    use crate::drivers::interface::rgb::RgbCommand;
+    use crate::{config::CONST_CONFIG, drivers::interface::rgb::RgbCommand};
 
     use super::*;
 
-    pub(crate) static RGB_CHANNEL: Channel<RgbCommand, 3> = Channel::new();
+    pub(crate) static RGB_CHANNEL: Channel<RgbCommand, { CONST_CONFIG.buffer.rgb_channel }> =
+        Channel::new();
 
     /// Get [`DynamicSender`] that can be used to control RGB.
     pub fn rgb_sender() -> DynamicSender<'static, RgbCommand> {

--- a/lib/rktk/src/task/mod.rs
+++ b/lib/rktk/src/task/mod.rs
@@ -182,7 +182,12 @@ pub async fn start<
                                     )
                                     .await;
                                 },
-                                rgb::start::<RL, _>(drivers.rgb, hooks.rgb, Some(sender)),
+                                rgb::start::<RL, _>(
+                                    opts.config,
+                                    drivers.rgb,
+                                    hooks.rgb,
+                                    Some(sender)
+                                ),
                                 async move {
                                     if let Some(task) = task {
                                         task.await;
@@ -209,7 +214,7 @@ pub async fn start<
                                     )
                                     .await
                                 },
-                                rgb::start::<RL, _>(drivers.rgb, hooks.rgb, None),
+                                rgb::start::<RL, _>(opts.config, drivers.rgb, hooks.rgb, None),
                                 async move {
                                     if let Some(task) = task {
                                         task.await;

--- a/lib/rktk/src/task/mod.rs
+++ b/lib/rktk/src/task/mod.rs
@@ -182,14 +182,7 @@ pub async fn start<
                                     )
                                     .await;
                                 },
-                                async move {
-                                    if let Some(rgb) = drivers.rgb {
-                                        debug!("rgb init");
-                                        rgb::start::<RL, _>(rgb, hooks.rgb, sender).await;
-                                    } else {
-                                        debug!("no rgb");
-                                    }
-                                },
+                                rgb::start::<RL, _>(drivers.rgb, hooks.rgb, Some(sender)),
                                 async move {
                                     if let Some(task) = task {
                                         task.await;
@@ -216,6 +209,7 @@ pub async fn start<
                                     )
                                     .await
                                 },
+                                rgb::start::<RL, _>(drivers.rgb, hooks.rgb, None),
                                 async move {
                                     if let Some(task) = task {
                                         task.await;

--- a/lib/rktk/src/task/mod.rs
+++ b/lib/rktk/src/task/mod.rs
@@ -1,7 +1,7 @@
 //! Program entrypoint.
 
 use crate::{
-    config::{CONST_CONFIG, Hand},
+    config::Hand,
     drivers::interface::{
         debounce::DebounceDriver, display::DisplayDriver, encoder::EncoderDriver,
         keyscan::KeyscanDriver, mouse::MouseDriver, rgb::RgbDriver, split::SplitDriver,
@@ -57,6 +57,7 @@ pub async fn start<
     BH: RgbHooks,
     //
     DC: DisplayConfig + 'static,
+    RL: blinksy::layout::Layout2d + 'static,
 >(
     mut drivers: Drivers<
         System,
@@ -72,7 +73,7 @@ pub async fn start<
         Mouse,
     >,
     mut hooks: Hooks<CH, MH, SH, BH>,
-    mut opts: crate::config::RktkOpts<DC>,
+    mut opts: crate::config::RktkOpts<DC, RL>,
 ) {
     #[cfg(feature = "rrp-log")]
     {
@@ -83,15 +84,7 @@ pub async fn start<
         });
     }
 
-    info!(
-        "RKTK Starting... (rgb: {}, ble: {}, usb: {}, storage: {}, mouse: {}, display: {})",
-        drivers.rgb.is_some(),
-        drivers.ble_builder.is_some(),
-        drivers.usb_builder.is_some(),
-        drivers.storage.is_some(),
-        drivers.mouse.is_some(),
-        drivers.display.is_some(),
-    );
+    info!("Booting rktk",);
 
     drivers
         .system
@@ -130,6 +123,7 @@ pub async fn start<
                             receiver,
                             task,
                         } => {
+                            info!("Master start");
                             sjoin::join!(
                                 async {
                                     let config_store =
@@ -140,8 +134,6 @@ pub async fn start<
                                         opts.keymap,
                                     )
                                     .await;
-
-                                    info!("Master side task start");
 
                                     hooks
                                         .master
@@ -193,22 +185,7 @@ pub async fn start<
                                 async move {
                                     if let Some(rgb) = drivers.rgb {
                                         debug!("rgb init");
-                                        match hand {
-                                            Hand::Right => {
-                                                rgb::start::<
-                                                    { CONST_CONFIG.keyboard.right_rgb_count },
-                                                >(
-                                                    rgb, hooks.rgb, sender
-                                                )
-                                                .await
-                                            }
-                                            Hand::Left => rgb::start::<
-                                                { CONST_CONFIG.keyboard.left_rgb_count },
-                                            >(
-                                                rgb, hooks.rgb, sender
-                                            )
-                                            .await,
-                                        }
+                                        rgb::start::<RL, _>(rgb, hooks.rgb, sender).await;
                                     } else {
                                         debug!("no rgb");
                                     }
@@ -225,7 +202,7 @@ pub async fn start<
                             receiver,
                             task,
                         } => {
-                            debug!("slave start");
+                            debug!("Slave start");
                             sjoin::join!(
                                 async move {
                                     slave::start(

--- a/lib/rktk/src/task/rgb.rs
+++ b/lib/rktk/src/task/rgb.rs
@@ -121,11 +121,12 @@ pub async fn start<Layout: Layout2d, Driver: RgbDriver>(
                     current_rgb_mode = rgb_mode;
                 }
                 RgbCommand::Reset => {}
-                RgbCommand::Brightness(mut brightness_value) => {
-                    if brightness_value > 1.0 {
-                        brightness_value = 1.0;
-                    }
-                    brightness = brightness_value;
+                RgbCommand::Brightness(brightness_value) => {
+                    brightness = brightness_value.clamp(0.0, 1.0);
+                }
+                RgbCommand::BrightnessDelta(delta) => {
+                    brightness += delta;
+                    brightness = brightness.clamp(0.0, 1.0);
                 }
             }
         }

--- a/lib/rktk/src/task/rgb.rs
+++ b/lib/rktk/src/task/rgb.rs
@@ -2,13 +2,17 @@ use embassy_futures::select::{Either, select};
 use embassy_time::Duration;
 
 use crate::{
-    drivers::interface::{rgb::RgbDriver, split::MasterToSlave},
+    drivers::interface::{
+        rgb::{Rgb8, RgbCommand, RgbDriver, RgbMode, RgbPattern},
+        split::MasterToSlave,
+    },
     hooks::interface::RgbHooks,
 };
 
 use super::channels::{rgb::RGB_CHANNEL, split::M2sTx};
 use blinksy::{
     color::{ColorCorrection, IntoColor, LinearSrgb},
+    dimension::Dim2d,
     layout::Layout2d,
     pattern::Pattern,
     patterns::rainbow::{Rainbow, RainbowParams},
@@ -21,33 +25,105 @@ pub async fn start<Layout: Layout2d, Driver: RgbDriver>(
 ) {
     hook.on_rgb_init(&mut driver).await;
 
-    // FIXME: Demo
-    let pattern = <Rainbow as Pattern<_, Layout>>::new(RainbowParams::default());
-
+    let mut current_rgb_mode = RgbMode::Off;
     loop {
         let res = select(RGB_CHANNEL.receive(), async {
-            let interval = Duration::from_millis(16);
-            let mut i = 0;
-            let mut t = embassy_time::Ticker::every(interval);
-            loop {
-                t.next().await;
-                i += 1;
-                let led_data =
-                    <Rainbow as Pattern<_, Layout>>::tick(&pattern, (i * interval).as_millis())
-                        .map(|color| {
-                            let srgb: LinearSrgb = color.into_color();
-                            srgb
-                        });
-                let _ = driver
-                    .write(led_data, 0.0, ColorCorrection::default())
-                    .await;
+            hook.on_rgb_process(&mut driver, &mut current_rgb_mode)
+                .await;
+
+            match &current_rgb_mode {
+                RgbMode::Off => {
+                    let _ = driver
+                        .write(
+                            core::iter::repeat_n(Rgb8::new(0, 0, 0), Layout::PIXEL_COUNT),
+                            0.0,
+                            ColorCorrection::default(),
+                        )
+                        .await;
+                }
+                RgbMode::SolidColor(r, g, b) => {
+                    let _ = driver
+                        .write(
+                            core::iter::repeat_n(Rgb8::new(*r, *g, *b), Layout::PIXEL_COUNT),
+                            0.0,
+                            ColorCorrection::default(),
+                        )
+                        .await;
+                }
+                RgbMode::Pattern(pat) => {
+                    let interval = Duration::from_millis(16);
+                    let mut i = 0;
+                    let mut t = embassy_time::Ticker::every(interval);
+
+                    macro_rules! process_pattern {
+                        ($pattern_ty:ty, $params:expr) => {{
+                            let pattern = <$pattern_ty as Pattern<_, Layout>>::new($params);
+                            loop {
+                                t.next().await;
+                                i += 1;
+                                let led_data = <$pattern_ty as Pattern<_, Layout>>::tick(
+                                    &pattern,
+                                    (i * interval).as_millis(),
+                                )
+                                .map(|color| {
+                                    let srgb: LinearSrgb = color.into_color();
+                                    srgb.into()
+                                });
+                                let _ = driver
+                                    .write(led_data, 0.0, ColorCorrection::default())
+                                    .await;
+                            }
+                        }};
+                    }
+
+                    match pat {
+                        RgbPattern::Rainbow(time_scalar, position_scalar) => {
+                            process_pattern!(
+                                Rainbow,
+                                RainbowParams {
+                                    time_scalar: *time_scalar,
+                                    position_scalar: *position_scalar,
+                                }
+                            );
+                        }
+                    }
+                }
+                RgbMode::Custom => {
+                    // TODO: Implement this
+                }
             }
+            core::future::pending::<()>().await;
         })
         .await;
 
-        #[allow(irrefutable_let_patterns)]
         if let Either::First(new_ctrl) = res {
             let _ = m2s_tx.send(MasterToSlave::Rgb(new_ctrl.clone())).await;
+            match new_ctrl {
+                RgbCommand::Start(rgb_mode) => {
+                    current_rgb_mode = rgb_mode;
+                }
+                RgbCommand::Reset => {}
+            }
         }
+    }
+}
+
+struct TimeGradPat;
+impl<L: Layout2d> Pattern<Dim2d, L> for TimeGradPat {
+    type Params = ();
+    type Color = LinearSrgb;
+
+    fn new(_params: Self::Params) -> Self {
+        Self
+    }
+
+    fn tick(&self, time_in_ms: u64) -> impl Iterator<Item = Self::Color> {
+        (0..L::PIXEL_COUNT).map(move |i| {
+            LinearSrgb::new(
+                ((time_in_ms / 5 + i as u64 * 5) % 255) as f32 / 255.0,
+                (255 - (time_in_ms / 5 + i as u64 * 5) % 255) as f32 / 255.0,
+                0.0,
+            )
+        })
     }
 }

--- a/lib/rktk/src/task/rgb.rs
+++ b/lib/rktk/src/task/rgb.rs
@@ -30,7 +30,7 @@ pub async fn start<Layout: Layout2d, Driver: RgbDriver>(
         return;
     };
 
-    hook.on_rgb_init(&mut driver).await;
+    hook.on_rgb_init(&mut driver, m2s_tx.is_some()).await;
 
     let mut current_rgb_mode = RgbMode::Off;
     let mut brightness = config.rktk.rgb.default_brightness;
@@ -107,7 +107,7 @@ pub async fn start<Layout: Layout2d, Driver: RgbDriver>(
                     }
                 }
                 RgbMode::Custom => {
-                    // TODO: Implement this
+                    hook.custom_rgb(&mut driver, brightness).await;
                 }
             }
             core::future::pending::<()>().await;

--- a/lib/rktk/src/task/rgb.rs
+++ b/lib/rktk/src/task/rgb.rs
@@ -16,7 +16,10 @@ use blinksy::{
     color::{ColorCorrection, IntoColor, LedRgb, LinearSrgb},
     layout::Layout2d,
     pattern::Pattern,
-    patterns::rainbow::{Rainbow, RainbowParams},
+    patterns::{
+        noise::{Noise2d, NoiseParams, noise_fns::Perlin},
+        rainbow::{Rainbow, RainbowParams},
+    },
 };
 
 pub async fn start<Layout: Layout2d, Driver: RgbDriver>(
@@ -103,6 +106,9 @@ pub async fn start<Layout: Layout2d, Driver: RgbDriver>(
                                     position_scalar: *position_scalar,
                                 }
                             );
+                        }
+                        RgbPattern::NoisePerlin => {
+                            process_pattern!(Noise2d<Perlin>, NoiseParams::default());
                         }
                     }
                 }

--- a/tools/rktk-client/src/app/components/selector/key_code.rs
+++ b/tools/rktk-client/src/app/components/selector/key_code.rs
@@ -1,8 +1,8 @@
 use dioxus::prelude::*;
 use rktk::config::keymap::prelude::RktkKeys;
 use rktk_keymanager::keycode::{
-    key::Key, layer::LayerOp, media::Media, modifier::Modifier, mouse::Mouse, special::Special,
-    KeyCode,
+    KeyCode, key::Key, layer::LayerOp, media::Media, modifier::Modifier, mouse::Mouse,
+    special::Special,
 };
 use strum::IntoEnumIterator as _;
 
@@ -142,8 +142,8 @@ pub fn KeyCodeSelector(key_code: KeyCode, select_key_code: Callback<KeyCode>) ->
                     },
                     KeyCode::Custom1(id) => rsx! {
                         KeySelector {
-                            items: rktk::config::keymap::rktk_keys::RktkKeys::iter().collect(),
-                            selected_key: id.try_into().unwrap(),
+                            items: RktkKeys::iter().collect(),
+                            selected_key: RktkKeys::from_repr(id).expect("Invalid rktk key id"),
                             select_key: Callback::new(move |k| select_key_code(KeyCode::Custom1(k as u8))),
                         }
                     },

--- a/tools/rktk-client/src/app/page/connected/remap/keyboard.rs
+++ b/tools/rktk-client/src/app/page/connected/remap/keyboard.rs
@@ -150,7 +150,8 @@ mod utils {
             KeyCode::Special(special) => Into::<&'static str>::into(special).to_string(),
             KeyCode::Media(media) => Into::<&'static str>::into(media).to_string(),
             KeyCode::Custom1(n) => {
-                Into::<&'static str>::into(TryInto::<RktkKeys>::try_into(*n).unwrap()).to_string()
+                Into::<&'static str>::into(RktkKeys::from_repr(*n).expect("Invalid rktk key id"))
+                    .to_string()
             }
             KeyCode::Custom2(n) => format!("C2({n})"),
             KeyCode::Custom3(n) => format!("C3({n})"),


### PR DESCRIPTION
Attempt to implement RGB animation using [blinksy](https://github.com/ahdinosaur/blinksy)

## Considerations
- How to implement driver?
  - blinksy has own driver impl but it seems that async is not implemented currently.
    - Currently, don't use blinksy's driver and controller. Only uses pattern and layout 
  - Color is generic
    - Pattern should be able to be changed on the fly, so rktk driver trait only accepts linearsrgb, which is most common.
- RGB Layout
  - The keyboard RGB layout may not fit into a simple grid, in which case the layout definition becomes a bit cumbersome.
    - Something like [qmk's rgb matrix](https://docs.qmk.fm/features/rgb_matrix) woule be useful.
- Performance
  - Rainbow works well, but Noise2D seems to be calculation heavy, and especially, the mouse lags noticeably.
- Binary size
- Memory usage
  - The blinksy API uses iterators rather than arrays, so I don't expect the number to increase that much.